### PR TITLE
fix(README): add region of sso endpoint environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ chmod +x /usr/local/bin/update-1password-aws-credentials.sh
 # Usage
 
 ```shell
-export AWS_REGION=<YOUR SSO Endpoint Region>
+$ export AWS_REGION=<YOUR SSO Endpoint Region>
 $ aws-sso-go --profile <profile> | update-1password-aws-credentials.sh <1Password item name>
 $ cat .env
 AWS_ACCESS_KEY_ID="op://Private/<1Password item name>/access key id"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ chmod +x /usr/local/bin/update-1password-aws-credentials.sh
 # Usage
 
 ```shell
+export AWS_REGION=<YOUR SSO Endpoint Region>
 $ aws-sso-go --profile <profile> | update-1password-aws-credentials.sh <1Password item name>
 $ cat .env
 AWS_ACCESS_KEY_ID="op://Private/<1Password item name>/access key id"


### PR DESCRIPTION
I added the AWS region of the SSO endpoint as an environment variable to the README.
When I tried running `aws-sso-go`, an `invalid grant provided` error occurred if no region was specified.
After setting the SSO endpoint region to the environment variable, I was able to run it without any errors, so I added it to the README.
The following is an article that summarizes the details of the error 🙏🏾 
https://sadayoshi-tada.hatenablog.com/entry/2023/08/30/212751